### PR TITLE
Change default port from 8080 to 8081 as OLS uses 8080 by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Server configuration
 HOST=localhost          # The hostname for the server (default is "localhost")
-PORT=8080               # The port the server will listen on (default is "8080")
+PORT=8081               # The port the server will listen on (default is "8081")
 
 # Language model configuration
 LLM_NAME=llama3:latest  # Name of the language model (replace with your model name)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To run BEAM, you'll need:
 
    ```bash
    HOST=localhost
-   PORT=8080
+   PORT=8081
    LLM_NAME=llama3:latest
    LLM_API=http://localhost:11434/api/generate
    SSLMODE=disable

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ func LoadConfig() *Config {
 
 	configInstance = &Config{
 		Host:      getEnv("HOST", "localhost"),
-		Port:      getEnv("PORT", "8080"),
+		Port:      getEnv("PORT", "8081"),
 		ModelName: getEnv("LLM_NAME", DEFAULT_LLM),
 		ModelAPI:  getEnv("LLM_API", DEFAULT_LLM_URL),
 		SSLMode:   getEnv("SSLMODE", "disable"),

--- a/main.go
+++ b/main.go
@@ -10,6 +10,6 @@ import (
 func main() {
 	srv := server.NewACEServer()
 
-	// Start the server on port 8080
+	// Start the server on port 8081
 	log.Fatal(srv.Start())
 }


### PR DESCRIPTION
Change default port from 8080 to 8081 as OLS ([OpenShift lightspeed-service](https://github.com/openshift/lightspeed-service/)) uses 8080 by default