### PR TITLE
Add OpenShift lightspeed-service support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,8 @@ PORT=8081               # The port the server will listen on (default is "8081")
 LLM_NAME=llama3:latest  # Name of the language model (replace with your model name)
 LLM_API=http://localhost:11434/api/generate  # API endpoint for the LLM model
 
+# OLS (OpenShift Lightspeed Service) configuration
+OLS_API="http://localhost:8080" # API endpoint for the OLS API
+
 # SSL configuration
 SSLMODE=disable         # SSL mode for the server (default is "disable")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	ModelName string
 	ModelAPI  string
 	Host      string
+	OLSAPI    string
 	Port      string
 	SSLMode   string
 }
@@ -34,6 +35,7 @@ func LoadConfig() *Config {
 		Port:      getEnv("PORT", "8081"),
 		ModelName: getEnv("LLM_NAME", DEFAULT_LLM),
 		ModelAPI:  getEnv("LLM_API", DEFAULT_LLM_URL),
+		OLSAPI:    getEnv("OLS_API", DEFAULT_OLS_URL),
 		SSLMode:   getEnv("SSLMODE", "disable"),
 	}
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -14,4 +14,7 @@ const (
 	DEFAULT_LLM string = "llama3:latest"
 	// Default LLM URL
 	DEFAULT_LLM_URL = "http://localhost:11434/api/generate"
+
+	// Default OLS URL
+	DEFAULT_OLS_URL = "http://localhost:8080/v1/query"
 )

--- a/internal/config/requests.go
+++ b/internal/config/requests.go
@@ -5,3 +5,12 @@ type ChatRequest struct {
 	Prompt   string `json:"prompt"`
 	Question string `json:"question"`
 }
+
+// Struct to define the input for OLS /v1/query API
+type OLSRequest struct {
+	Model          string `json:model`
+	Provider       string `json:provider`
+	Query          string `json:"query"`
+	ConversationId string `json:conversation_id`
+	// TODO Attachments
+}

--- a/internal/config/responses.go
+++ b/internal/config/responses.go
@@ -12,3 +12,11 @@ type OllamaResponse struct {
 	Response string `json:"response"`
 	Done     bool   `json:"done"`
 }
+
+// Reponse from OLS /v1/query API
+type OLSResponse struct {
+	ConversationId string `json:"conversation_id"`
+	Response       string `json:"response"`
+	Truncated      bool   `json:"truncated"`
+	// TODO ReferencedDocuments
+}

--- a/internal/server/query _ols.go
+++ b/internal/server/query _ols.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/morfo-si/beam/internal/config"
+)
+
+// Function to query the LLM API
+func queryOLS(fullPrompt string) (string, error) {
+	// Define the request body for the LLM API
+	requestBody := config.OllamaRequest{
+		Model:  config.LoadConfig().ModelName,
+		Prompt: fullPrompt,
+	}
+
+	// Marshal the request body to JSON
+	jsonData, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling request: %v", err)
+	}
+
+	// Send the request to the local LLM API
+	resp, err := http.Post(config.LoadConfig().ModelAPI, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("error sending request to LLM: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading LLM response: %v", err)
+	}
+
+	// Parse and concatenate the streaming response from LLaMA
+	var responseParts []string
+	reader := bytes.NewReader(body)
+	decoder := json.NewDecoder(reader)
+
+	// Iterate through the streaming response and concatenate
+	for decoder.More() {
+		var part config.OllamaResponse
+		if err := decoder.Decode(&part); err != nil {
+			return "", fmt.Errorf("error decoding LLM response: %v", err)
+		}
+		responseParts = append(responseParts, part.Response)
+
+		if part.Done {
+			break
+		}
+	}
+
+	// Return the concatenated response
+	return concatResponses(responseParts), nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ type Server interface {
 	Start() error
 	Query(c fiber.Ctx) error
 	App() *fiber.App
+	QueryOLS(c fiber.Ctx) error
 }
 
 type ACEServer struct {
@@ -55,6 +56,7 @@ func NewACEServer() Server {
 	}
 
 	server.app.Post("/api/v1/chat", server.Query)
+	server.app.Post("/api/v1/ols", server.QueryOLS)
 	return server
 }
 

--- a/internal/server/server_query_ols.go
+++ b/internal/server/server_query_ols.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"github.com/morfo-si/beam/internal/config"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// ACEServer struct
+func (ace *ACEServer) QueryOLS(c fiber.Ctx) error {
+	// Parse the request body
+	var chatRequest config.ChatRequest
+	if err := c.Bind().Body(&chatRequest); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+
+	// Note: Prompt is ignored when OLS is used.
+
+	if chatRequest.Question == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Question is required for OLS"})
+	}
+
+	// Send the question to the OLS
+	concatenatedResponse, err := queryOLS(chatRequest.Question)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	// Return the concatenated response as JSON
+	return c.Status(fiber.StatusOK).JSON(fiber.Map{"response": concatenatedResponse})
+}


### PR DESCRIPTION
Add [OpenShift lightspeed-service](https://github.com/openshift/lightspeed-service/) (OLS) as a supported backend service to the currently supported Ollama.

1. This will add a new endpoint `/api/v1/ols` to beam, i.e. the OLS support will co-exist with the Ollama support at least for now.
2. Corresponding UI support is needed. It will be done soon.
3. Following OLS features are not supported in this PR:
    - **`conversation_id` support** OLS returns a `conversation_id`, which is (probably) used for preserving a context of conversation with the current user. I think we need to support it and I am planning to add changes later.
    - **`attachments` (in requests) / `referenced_documents` (in responses)** These fields are not used at least for now.
4. **OLS NEEDS TO BE MODIFIED FOR ACCEPTING ANSIBLE QUESTIONS** I used [this branch of OLS](https://github.com/durham-hackason-2024-09/lightspeed-service/tree/hackathon) for my test. I may need to provide an image to capture those changes.